### PR TITLE
Update the checkout action to v3 to eliminate Node v12 deprecation warning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,11 @@ jobs:
       matrix:
         ruby:
           - 3.2
+          - 3.3
           - head
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
           - head
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: RuboCop Linter Action
       uses: andrewmcodes/rubocop-linter-action@v3.3.0
       env:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -6,8 +6,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: RuboCop Linter Action
-      uses: andrewmcodes/rubocop-linter-action@v3.3.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.2
+        bundler-cache: true
+
+    - name: Run the RuboCop task
+      run: bundle exec rake rubocop


### PR DESCRIPTION
This PR also updates the now unsupported `andrewmcodes/rubocop-linter-action` with a standard rake invocation of Rubocop.  The former failed for unknown reasons, while the new verson succeeds.

Runs green on my fork.