### PR TITLE
Update accept_language.rb

### DIFF
--- a/lib/accept_language.rb
+++ b/lib/accept_language.rb
@@ -23,7 +23,7 @@ module AcceptLanguage
   #
   # @return [Parser] a Parser object that responds to #match method.
   def self.parse(field)
-    Parser.new(field)
+    Parser.new(field.to_s)
   end
 end
 


### PR DESCRIPTION
How to reproduce:

`AcceptLanguage.parse(nil)`

Raise an error
```
/.rvm/gems/ruby-3.1.2/gems/accept_language-2.0.3/lib/accept_language/parser.rb:40:in `import': undefined method `delete' for nil:NilClass (NoMethodError)                   
                                             
      field.delete(SPACE).split(SEPARATOR).inject({}) do |hash, lang|
```

I would recommend to add a casting in the parse function

```
def self.parse(value)
   value = value.to_s
    ....
end
```