### PR TITLE
Update "add to Gemfile" instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ bundle install
 Or install it yourself as:
 
 ```sh
-gem install accept_language
+bundle add accept_language
 ```
 
 ## Usage


### PR DESCRIPTION
This uses the newer, "bundle add" rather than "gem install" in the installation instructions.