### PR TITLE
Restrict header values by following specification

### DIFF
--- a/lib/accept_language/parser.rb
+++ b/lib/accept_language/parser.rb
@@ -16,6 +16,8 @@ module AcceptLanguage
     SEPARATOR = ","
     SPACE = " "
     SUFFIX = ";q="
+    ALLOWED_TAG_CHARS = ("a".."z").to_a + ("A".."Z").to_a + ("0".."9").to_a + ["-", "*"]
+    ALLOWED_QUALITY_CHARS = ("0".."9").to_a + ["."]
 
     attr_reader :languages_range
 
@@ -50,7 +52,10 @@ module AcceptLanguage
     def import(field)
       "#{field}".delete(SPACE).split(SEPARATOR).inject({}) do |hash, lang|
         tag, quality = lang.split(SUFFIX)
-        next hash if tag.nil?
+
+        invalid_tag = tag.nil? || (tag.chars - ALLOWED_TAG_CHARS).any?
+        invalid_quality = !quality.nil? && (quality.chars - ALLOWED_QUALITY_CHARS).any?
+        next hash if invalid_tag || invalid_quality
 
         quality = quality.nil? ? DEFAULT_QUALITY : BigDecimal(quality)
         hash.merge(tag => quality)


### PR DESCRIPTION
A language tag (which is sometimes referred to as a "locale identifier"). This consists of a 2-3 letter base language tag that indicates a language, optionally followed by additional subtags separated by '-'. The most common extra information is the country or region variant (like 'en-US' or 'fr-CA') or the type of alphabet to use (like 'sr-Latn'). Other variants, like the type of orthography ('de-DE-1996'), are usually not used in the context of this header. Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language

The importance of a value is marked by the suffix ';q=' immediately followed by a value between 0 and 1 included, with up to three decimal digits, the highest value denoting the highest priority. When not present, the default value is 1. Reference: https://developer.mozilla.org/en-US/docs/Glossary/Quality_values