### PR TITLE
Add the ability to fallback to a primary locale

### DIFF
--- a/lib/accept_language/parser.rb
+++ b/lib/accept_language/parser.rb
@@ -34,8 +34,8 @@ module AcceptLanguage
     #   match(:ug, :kk, :ru, :en)
     #
     # @return [String, Symbol, nil] The language tag that best matches the parsed languages from the Accept-Language header, or nil if no match found.
-    def match(*available_langtags)
-      Matcher.new(**languages_range).call(*available_langtags)
+    def match(*available_langtags, primary_fallback: false)
+      Matcher.new(primary_fallback:, **languages_range).call(*available_langtags)
     end
 
     private

--- a/spec/accept_language/matcher_spec.rb
+++ b/spec/accept_language/matcher_spec.rb
@@ -4,10 +4,11 @@ require_relative File.join("..", "spec_helper")
 
 RSpec.describe AcceptLanguage::Matcher do
   let(:matcher) do
-    described_class.new(**AcceptLanguage::Parser.new(field).languages_range)
+    described_class.new(primary_fallback:, **AcceptLanguage::Parser.new(field).languages_range)
   end
 
   let(:best_match) { matcher.call(*available_langtags) }
+  let(:primary_fallback) { false }
 
   context "when asking for Chinese (Taiwan)" do
     let(:available_langtags) { [available_langtag] }
@@ -35,6 +36,34 @@ RSpec.describe AcceptLanguage::Matcher do
       let(:available_langtag) { "ug-CN" }
 
       it { expect(best_match).to be_nil }
+    end
+
+    context "when primary_fallback is in true" do
+      let(:primary_fallback) { true }
+
+      context "when Chinese is available" do
+        let(:available_langtag) { "zh" }
+
+        it { expect(best_match).to eq "zh" }
+      end
+
+      context "when Chinese (Hong Kong) is available" do
+        let(:available_langtag) { "zh-HK" }
+
+        it { expect(best_match).to be_nil }
+      end
+
+      context "when Chinese (Taiwan) is available" do
+        let(:available_langtag) { "zh-TW" }
+
+        it { expect(best_match).to eq "zh-TW" }
+      end
+
+      context "when Uyghur (China) is available" do
+        let(:available_langtag) { "ug-CN" }
+
+        it { expect(best_match).to be_nil }
+      end
     end
   end
 


### PR DESCRIPTION
Hi @cyril thanks for the work on this gem! 

I'm opening this PR, but not sure if this is something that you would be interested to add into the gem. The idea of this change is to be able to fallback to a primary language locale if an extra argument is passed to the `.match` method, and in that case if all the preferred locales doesn't match with the available locales, a last attempt is made to match a primary locale.

Let me know if you have any concerns or comments about it!
Many thanks!